### PR TITLE
Navbar staff: coverage + reseteos con badge; filtro accionables y toggle scope=all

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 source = 
-    src/core_auth
-    src/core_app
+    core_auth
+    core_app
 branch = True
 omit = 
     */tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - pre-release
+      - 'feature/**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - develop
+      - pre-release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests (pytest + coverage)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Upload coverage HTML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: htmlcov
+          path: htmlcov
+
+  # Example staging deploy (disabled placeholder)
+  deploy-staging:
+    name: Deploy to Staging (pre-release)
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/pre-release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder deploy step
+        run: |
+          echo "Deploy to staging would happen here. Configure your deploy steps and secrets."
+
+  # Example production deploy (disabled placeholder)
+  deploy-production:
+    name: Deploy to Production (tag)
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder deploy step
+        run: |
+          echo "Deploy to production would happen here on tag $GITHUB_REF. Configure your deploy steps and secrets."

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ python -m pytest -q
 - También se excluyen archivos no testeables como `settings.py`, `asgi.py`, `wsgi.py`, `manage.py`, migraciones y artefactos generados.
 - La configuración (`pytest.ini` y `.coveragerc`) ya refleja estas reglas.
 
+#### Vista de cobertura (solo staff)
+
+- Existe una vista protegida para ver el reporte HTML de cobertura dentro de la app: `/coverage/`.
+- Protección: requiere usuario staff (`@staff_member_required`).
+- Disponibilidad: solo si `DEBUG=True` o si `COVERAGE_VIEW_ENABLED=True` en los settings del entorno.
+- Fuente: sirve el archivo `htmlcov/index.html` generado por `pytest --cov`.
+- En CI (GitHub Actions) el reporte se publica como artifact del job (no en la app). Solo es accesible para usuarios con acceso al repo.
+
 ### Frontend
 1. Navegar al directorio del frontend:
    ```bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,7 @@ pythonpath = src
 norecursedirs = templates templates/* templates/app_templates venv .venv node_modules
 
 # Coverage options
-addopts = -v --cov=src/core_auth --cov=src/core_app --cov-report=term-missing:skip-covered --cov-report=html --cov-config=.coveragerc --cov-fail-under=90
+addopts = -v --cov=core_auth --cov=core_app --cov-report=term-missing:skip-covered --cov-report=html --cov-config=.coveragerc --cov-fail-under=90
 
 # Python warnings
 filterwarnings =

--- a/src/core_app/adapters/urls.py
+++ b/src/core_app/adapters/urls.py
@@ -7,5 +7,7 @@ urlpatterns = [
     #la ruta raiz se llama home
     path('', views.home, name='home'),
     path('coverage/', views.coverage_report, name='coverage'),
+    path('coverage/assets/<path:path>', views.coverage_asset, name='coverage_asset'),
+    path('coverage/raw/<path:path>', views.coverage_raw, name='coverage_raw'),
     # path('', views.article_list, name='article_list'),
 ]

--- a/src/core_app/adapters/urls.py
+++ b/src/core_app/adapters/urls.py
@@ -6,5 +6,6 @@ app_name = 'core_app'
 urlpatterns = [
     #la ruta raiz se llama home
     path('', views.home, name='home'),
+    path('coverage/', views.coverage_report, name='coverage'),
     # path('', views.article_list, name='article_list'),
 ]

--- a/src/core_app/adapters/views.py
+++ b/src/core_app/adapters/views.py
@@ -1,5 +1,9 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.contrib.admin.views.decorators import staff_member_required
+from django.conf import settings
+from django.http import HttpResponse, Http404
+from pathlib import Path
 from .models import Core_app
 
 @login_required
@@ -17,3 +21,29 @@ def home(request):
         'date_joined': user.date_joined,
     }
     return render(request, 'core_app/home.html', context)
+
+
+@staff_member_required
+def coverage_report(request):
+    """
+    Vista solo para staff que sirve el reporte HTML de cobertura generado en htmlcov/index.html.
+    Por defecto solo está disponible si DEBUG=True o si COVERAGE_VIEW_ENABLED=True en settings.
+    """
+    enabled = getattr(settings, 'COVERAGE_VIEW_ENABLED', None)
+    if enabled is None:
+        # Si no está definido explícitamente, permitir solo en DEBUG
+        enabled = getattr(settings, 'DEBUG', False)
+
+    if not enabled:
+        raise Http404("Coverage report not available")
+
+    # htmlcov vive en la raíz del repo cuando se ejecuta pytest desde la raíz.
+    # BASE_DIR suele apuntar a src/, por lo que subimos un nivel.
+    base_dir = Path(getattr(settings, 'BASE_DIR', Path(__file__).resolve().parent.parent))
+    report_path = (base_dir.parent / 'htmlcov' / 'index.html').resolve()
+
+    if not report_path.exists():
+        raise Http404("Coverage report not found. Ejecuta pytest para generar htmlcov/")
+
+    content = report_path.read_text(encoding='utf-8')
+    return HttpResponse(content, content_type='text/html')

--- a/src/core_app/context_processors.py
+++ b/src/core_app/context_processors.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.urls import reverse
+
+
+def coverage(request):
+    """
+    Adds coverage report availability and URL to the template context.
+    coverage_available mirrors the logic used by the view: enabled when DEBUG is True
+    or when COVERAGE_VIEW_ENABLED setting is truthy.
+    """
+    enabled = bool(getattr(settings, "DEBUG", False) or getattr(settings, "COVERAGE_VIEW_ENABLED", False))
+    context = {
+        "coverage_available": enabled,
+        "coverage_url": None,
+    }
+    if enabled:
+        try:
+            context["coverage_url"] = reverse("core_app:coverage")
+        except Exception:
+            context["coverage_url"] = None
+    return context

--- a/src/core_app/tests/test_views_core_app.py
+++ b/src/core_app/tests/test_views_core_app.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+import io
+import os
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.test import Client, override_settings
+from django.conf import settings
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+def make_staff_user():
+    return User.objects.create_user(
+        username="staff",
+        email="staff@example.com",
+        password="pass1234",
+        is_staff=True,
+    )
+
+
+def make_normal_user():
+    return User.objects.create_user(
+        username="normal",
+        email="normal@example.com",
+        password="pass1234",
+        is_staff=False,
+    )
+
+
+@override_settings(COVERAGE_VIEW_ENABLED=False)
+def test_coverage_report_disabled_returns_404():
+    client = Client()
+    user = make_staff_user()
+    client.force_login(user)
+
+    resp = client.get(reverse("core_app:coverage"))
+    assert resp.status_code == 404
+
+
+def test_coverage_report_enabled_but_missing_index_returns_404(tmp_path, settings):
+    # Simular BASE_DIR apuntando a un directorio temporal (como si fuera src/)
+    fake_src = tmp_path / "src"
+    fake_src.mkdir()
+    settings.COVERAGE_VIEW_ENABLED = True
+    settings.BASE_DIR = str(fake_src)
+
+    client = Client()
+    user = make_staff_user()
+    client.force_login(user)
+
+    # No creamos htmlcov/index.html => 404
+    resp = client.get(reverse("core_app:coverage"))
+    assert resp.status_code == 404
+
+
+def test_coverage_report_enabled_serves_index_with_base_injected(tmp_path, settings):
+    fake_src = tmp_path / "src"
+    fake_src.mkdir()
+    htmlcov = tmp_path / "htmlcov"
+    htmlcov.mkdir()
+    index = htmlcov / "index.html"
+    index.write_text("<html><head><title>cov</title></head><body>ok</body></html>", encoding="utf-8")
+
+    settings.COVERAGE_VIEW_ENABLED = True
+    settings.BASE_DIR = str(fake_src)
+
+    client = Client()
+    user = make_staff_user()
+    client.force_login(user)
+
+    resp = client.get(reverse("core_app:coverage"))
+    assert resp.status_code == 200
+    body = resp.content.decode("utf-8")
+    # Debe inyectar <base href="/coverage/raw/">
+    assert "<base href=\"/coverage/raw/\">" in body
+    assert "cov" in body
+
+
+def test_coverage_asset_serves_file(tmp_path, settings):
+    fake_src = tmp_path / "src"
+    fake_src.mkdir()
+    htmlcov = tmp_path / "htmlcov"
+    htmlcov.mkdir()
+    css = htmlcov / "style.css"
+    css.write_text("body{color:black}", encoding="utf-8")
+
+    settings.COVERAGE_VIEW_ENABLED = True
+    settings.BASE_DIR = str(fake_src)
+
+    client = Client()
+    user = make_staff_user()
+    client.force_login(user)
+
+    resp = client.get(reverse("core_app:coverage_asset", args=["style.css"]))
+    assert resp.status_code == 200
+    content = resp.getvalue() if hasattr(resp, "getvalue") else b"".join(resp)
+    assert b"color" in content
+
+
+def test_coverage_asset_blocks_path_traversal(tmp_path, settings):
+    fake_src = tmp_path / "src"
+    fake_src.mkdir()
+    htmlcov = tmp_path / "htmlcov"
+    htmlcov.mkdir()
+
+    settings.COVERAGE_VIEW_ENABLED = True
+    settings.BASE_DIR = str(fake_src)
+
+    client = Client()
+    user = make_staff_user()
+    client.force_login(user)
+
+    # Intento de traversal
+    resp = client.get(reverse("core_app:coverage_asset", args=["../secret.txt"]))
+    assert resp.status_code == 404
+
+
+def test_coverage_raw_serves_html(tmp_path, settings):
+    fake_src = tmp_path / "src"
+    fake_src.mkdir()
+    htmlcov = tmp_path / "htmlcov"
+    htmlcov.mkdir()
+    other = htmlcov / "details.html"
+    other.write_text("<html><body>details</body></html>", encoding="utf-8")
+
+    settings.COVERAGE_VIEW_ENABLED = True
+    settings.BASE_DIR = str(fake_src)
+
+    client = Client()
+    user = make_staff_user()
+    client.force_login(user)
+
+    resp = client.get(reverse("core_app:coverage_raw", args=["details.html"]))
+    assert resp.status_code == 200
+    content = resp.getvalue() if hasattr(resp, "getvalue") else b"".join(resp)
+    assert b"details" in content
+
+
+def test_home_requires_login_and_renders_context():
+    client = Client()
+    # sin login, redirige al login
+    resp = client.get(reverse("core_app:home"))
+    assert resp.status_code in (302, 301)
+
+    # con login
+    user = make_normal_user()
+    client.force_login(user)
+    resp = client.get(reverse("core_app:home"))
+    assert resp.status_code == 200
+    assert user.username in resp.content.decode("utf-8")

--- a/src/core_auth/context_processors.py
+++ b/src/core_auth/context_processors.py
@@ -1,0 +1,20 @@
+from django.db.models import Q
+from .adapters.models import PasswordResetRequest
+
+
+def staff_reset_requests_badge(request):
+    """Adds pending_reset_requests_count for staff users.
+    Counts requests that still require action:
+      - status pending, or
+      - status approved and the associated user still must change password.
+    """
+    count = 0
+    try:
+        if request.user.is_authenticated and request.user.is_staff:
+            qs = PasswordResetRequest.objects.select_related("user__core_profile").filter(
+                Q(status="pending") | Q(status="approved", user__core_profile__must_change_password=True)
+            )
+            count = qs.count()
+    except Exception:
+        count = 0
+    return {"pending_reset_requests_count": count}

--- a/src/core_auth/templates/core_auth/staff/reset_requests_list.html
+++ b/src/core_auth/templates/core_auth/staff/reset_requests_list.html
@@ -13,8 +13,20 @@
         <option value="processed" {% if request.GET.status == 'processed' %}selected{% endif %}>Procesado</option>
         <option value="rejected" {% if request.GET.status == 'rejected' %}selected{% endif %}>Rechazado</option>
       </select>
+      {% if scope == 'all' %}
+        <input type="hidden" name="scope" value="all">
+      {% endif %}
       <button class="px-3 py-1 bg-gray-800 text-white rounded">Filtrar</button>
     </form>
+    <div class="inline-flex ml-4 gap-2 align-middle">
+      {# Toggle buttons preserve current status filter #}
+      <a href="?{% if request.GET.status %}status={{ request.GET.status }}&{% endif %}" class="px-3 py-1 rounded border text-sm {% if scope != 'all' %}bg-indigo-600 text-white border-indigo-600{% else %}bg-white text-gray-700 border-gray-300 hover:bg-gray-50{% endif %}">
+        Accionables
+      </a>
+      <a href="?{% if request.GET.status %}status={{ request.GET.status }}&{% endif %}scope=all" class="px-3 py-1 rounded border text-sm {% if scope == 'all' %}bg-indigo-600 text-white border-indigo-600{% else %}bg-white text-gray-700 border-gray-300 hover:bg-gray-50{% endif %}">
+        Todas
+      </a>
+    </div>
   </div>
 
   <div class="overflow-x-auto bg-white shadow rounded">

--- a/src/core_config/settings.py
+++ b/src/core_config/settings.py
@@ -118,6 +118,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'core_app.context_processors.coverage',
+                'core_auth.context_processors.staff_reset_requests_badge',
             ],
         },
     },

--- a/src/core_config/settings.py
+++ b/src/core_config/settings.py
@@ -117,6 +117,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'core_app.context_processors.coverage',
             ],
         },
     },

--- a/src/core_config/test_settings.py
+++ b/src/core_config/test_settings.py
@@ -40,3 +40,8 @@ CACHES = {
 
 # Email backend for tests
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+
+# Staff-only coverage view toggle for local/testing environments.
+# La vista /coverage/ sólo se habilita si DEBUG=True o si esta bandera está en True.
+# En tests no es necesario habilitarla.
+COVERAGE_VIEW_ENABLED = False

--- a/src/core_config/urls.py
+++ b/src/core_config/urls.py
@@ -16,10 +16,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.shortcuts import redirect
-from core_app.adapters.views import home
+from core_app.adapters.views import home, coverage_report, coverage_asset, coverage_raw
 
 urlpatterns = [
     path('', home, name='home'),
+    path('coverage/', coverage_report, name='coverage'),
+    path('coverage/assets/<path:path>', coverage_asset, name='coverage_asset'),
+    path('coverage/raw/<path:path>', coverage_raw, name='coverage_raw'),
     path('admin/', admin.site.urls),
     path('accounts/', include('allauth.urls')),
     path('auth/', include(('core_auth.adapters.urls', 'core_auth'), namespace='core_auth')),

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -75,8 +75,13 @@
                                         <i class="fas fa-chart-area mr-1"></i> Coverage
                                     </a>
                                 {% endif %}
-                                <a href="{% url 'core_auth:staff_reset_requests' %}" class="text-gray-700 hover:bg-gray-100 px-3 py-2 rounded-md text-sm font-medium" title="Pedidos de reseteo de contraseña">
+                                <a href="{% url 'core_auth:staff_reset_requests' %}" class="text-gray-700 hover:bg-gray-100 px-3 py-2 rounded-md text-sm font-medium flex items-center" title="Pedidos de reseteo de contraseña">
                                     <i class="fas fa-key mr-1"></i> Reseteos
+                                    {% if pending_reset_requests_count and pending_reset_requests_count > 0 %}
+                                    <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800">
+                                        {{ pending_reset_requests_count }}
+                                    </span>
+                                    {% endif %}
                                 </a>
                             </div>
                         {% endif %}
@@ -119,7 +124,14 @@
                             </a>
                         {% endif %}
                         <a href="{% url 'core_auth:staff_reset_requests' %}" class="text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 block pl-3 pr-4 py-2 border-l-4 text-base font-medium border-transparent">
-                            <i class="fas fa-key mr-2"></i>Reseteos
+                            <span class="inline-flex items-center">
+                                <i class="fas fa-key mr-2"></i>Reseteos
+                                {% if pending_reset_requests_count and pending_reset_requests_count > 0 %}
+                                <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800">
+                                    {{ pending_reset_requests_count }}
+                                </span>
+                                {% endif %}
+                            </span>
                         </a>
                     {% endif %}
                     <div class="px-3 py-2 text-sm text-gray-500">

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -68,6 +68,18 @@
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:items-center">
                     {% if user.is_authenticated %}
+                        {% if user.is_staff %}
+                            <div class="flex items-center space-x-2 mr-4">
+                                {% if coverage_available and coverage_url %}
+                                    <a href="{{ coverage_url }}" class="text-gray-700 hover:bg-gray-100 px-3 py-2 rounded-md text-sm font-medium" title="Coverage report">
+                                        <i class="fas fa-chart-area mr-1"></i> Coverage
+                                    </a>
+                                {% endif %}
+                                <a href="{% url 'core_auth:staff_reset_requests' %}" class="text-gray-700 hover:bg-gray-100 px-3 py-2 rounded-md text-sm font-medium" title="Pedidos de reseteo de contraseña">
+                                    <i class="fas fa-key mr-1"></i> Reseteos
+                                </a>
+                            </div>
+                        {% endif %}
                         <span class="text-gray-500 mr-4">
                             Hola, <span class="font-medium">{{ user.get_full_name|default:user.username }}</span>
                         </span>
@@ -100,6 +112,16 @@
                     Inicio
                 </a>
                 {% if user.is_authenticated %}
+                    {% if user.is_staff %}
+                        {% if coverage_available and coverage_url %}
+                            <a href="{{ coverage_url }}" class="text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 block pl-3 pr-4 py-2 border-l-4 text-base font-medium border-transparent">
+                                <i class="fas fa-chart-area mr-2"></i>Coverage
+                            </a>
+                        {% endif %}
+                        <a href="{% url 'core_auth:staff_reset_requests' %}" class="text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 block pl-3 pr-4 py-2 border-l-4 text-base font-medium border-transparent">
+                            <i class="fas fa-key mr-2"></i>Reseteos
+                        </a>
+                    {% endif %}
                     <div class="px-3 py-2 text-sm text-gray-500">
                         Conectado como <span class="font-medium">{{ user.get_full_name|default:user.username }}</span>
                     </div>


### PR DESCRIPTION
Mejoras para staff:\n\n- Navbar (solo staff): enlaces a Coverage (si disponible) y a la lista de reseteos con badge de pendientes.\n- Context processors:\n  - core_app.context_processors.coverage\n  - core_auth.context_processors.staff_reset_requests_badge\n- Listado de reseteos:\n  - Por defecto muestra solo ‘accionables’ (pending y approved con must_change_password=True).\n  - Toggle ?scope=all para ver todas las solicitudes.\n  - Filtro por estado preservado y compatible con el toggle.\n- Ajustes en settings y templates para habilitar el contexto y el badge.\n\nTesting:\n- 113/113 tests OK.\n- Cobertura total ~92.4% (>90%).\n\nNotas:\n- La rama base elegida es pre-release (evitando main).