### PR TITLE
fix(config): cargar .env con AutoConfig (app_name/version en templates)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalizar finales de línea para compatibilidad Linux/Windows
+*.sh text eol=lf
+Dockerfile text eol=lf
+docker-compose.yml text eol=lf

--- a/docs/GIT_AGENTES.md
+++ b/docs/GIT_AGENTES.md
@@ -10,6 +10,17 @@ Guía de flujo de trabajo Git para agentes y colaboradores.
     - `feature/doc/git-workflow`
     - `feature/core_auth/reset-flow-dni-wsp`
 
+### Ramas de corrección `fix/*`
+- Objetivo: corregir defectos detectados en integración/QA antes del release.
+- Origen: SIEMPRE crear a partir de `pre-release` (no desde `develop`).
+- Nombre: `fix/{area}/{descripcion-corta}`.
+- Flujo:
+  1) `git checkout pre-release && git pull --ff-only`
+  2) `git checkout -b fix/{area}/{descripcion}`
+  3) Commits atómicos con tipo `fix:` o `docs/chore` si aplica.
+  4) Abrir PR base `pre-release` (no a `main`).
+  5) Tras merge en `pre-release`, sincronizar `develop` (ver Sync) si corresponde.
+
 > Nota (trabajo en solitario): este repositorio está pensado para 1 desarrollador. Se prefieren PRs para historial claro, pero se permiten merges directos cuando no haya revisor, manteniendo las validaciones (tests verdes) y mensajes de commit con Conventional Commits.
 
 ## Crear una rama feature
@@ -106,3 +117,5 @@ git checkout develop && git pull --ff-only && git merge --no-ff origin/pre-relea
 - Abrir PR a pre-release (con gh): `gh pr create --base pre-release --head feature/{app}/{desc} ...`
 - Sync pre-release -> develop: `git checkout develop && git fetch && git merge --no-ff origin/pre-release -m "Merge pre-release into develop"`
 - Release: PR `pre-release` -> `main`, luego tag `vX.Y.Z` y push del tag.
+ - Crear fix: `git checkout pre-release && git pull --ff-only && git checkout -b fix/{area}/{desc}`
+ - Abrir PR fix a pre-release: `gh pr create --base pre-release --head fix/{area}/{desc} ...`

--- a/src/core_config/settings.py
+++ b/src/core_config/settings.py
@@ -13,10 +13,14 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 import importlib
 import os
-from decouple import config
+from decouple import AutoConfig
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Use python-decouple with explicit search path to ensure src/.env is loaded
+# regardless of the working directory (e.g., inside Docker or local dev)
+config = AutoConfig(search_path=BASE_DIR)
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
﻿Motivo
- En algunos entornos no se cargaba src/.env, causando que `NOMBRE_APLICACION` caiga al default.

Cambios
- settings.py: AutoConfig(search_path=BASE_DIR).
- docs/GIT_AGENTES.md: ramas fix/* desde pre-release.
- .gitattributes: normalizar EOL.

Validación
- El context processor `core_app.context_processors.app_meta` expone `app_name` desde .env y la versión desde CHANGELOG.md.
