### PR TITLE
fix(ci): permisos contents:write para action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
﻿Motivo
- El workflow de release fallaba con 403 por permisos insuficientes del GITHUB_TOKEN.

Cambio
- Nuevo workflow .github/workflows/release.yml con:
  permissions:
    contents: write
- Usa softprops/action-gh-release@v2 al pushear tags v*.*.*.

Resultado
- Los tags vX.Y.Z disparan la creación del Release sin error 403.
