### PR TITLE
feat: centralizar persistencia con patrón persist/ por host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,11 @@ src/staticfiles/*
 frontend/*
 src/data/*
 static/*
+# Persistencia centralizada (evitar commits accidentales si alguien crea la carpeta dentro del repo)
+/persist/
+/persist/**
+
+# Archivos sensibles y artefactos locales
+src/.env
+src/media/
+logs/

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Breve descripción del proyecto. Este repositorio se generó a partir de la plan
 - Guía completa de DjangoProyects: ver [docs/DJANGOPROYECTS.md](docs/DJANGOPROYECTS.md).
 - Instalación y comandos rápidos: ver [docs/INSTALACION.md](docs/INSTALACION.md).
 
-## Primeros pasos
+### Persistencia en producción
 
-1. Copia `src/.env.example` a `src/.env` y ajusta las variables.
-2. Crea y activa un entorno virtual, instala dependencias y migra la base de datos.
-3. Ejecuta el servidor de desarrollo con `python ./src/manage.py runserver`.
-
-Para lineamientos de trabajo y git flow, consulta [docs/PAUTAS_AGENTES.md](docs/PAUTAS_AGENTES.md) y [docs/GIT_AGENTES.md](docs/GIT_AGENTES.md).
+Este template adopta una carpeta `persist/` por host para centralizar secretos, media, data y logs mediante bind mounts controlados por `HOST_PERSIST` (default `.` en desarrollo).
+Consulta detalles y pasos en:
+- [docs/DJANGOPROYECTS.md](docs/DJANGOPROYECTS.md#patrón-de-persistencia-centralizada-persist)
+- [docs/INSTALACION.md](docs/INSTALACION.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,9 @@ services:
       - ENABLE_COLLECTSTATIC=false
       # Desactiva frontend si no quieres construir Tailwind (por defecto se construye)
       - NO_FRONTEND=false
-    # Opcional: montar volumen si quieres persistir DB sqlite fuera del contenedor
-    # volumes:
-    #   - ./src/data:/app/src/data
-    #   - ./static:/app/static
+    volumes:
+      - ${HOST_PERSIST:-.}/persist/env/.env:/app/src/.env:ro
+      - ${HOST_PERSIST:-.}/persist/media:/app/src/media
+      - ${HOST_PERSIST:-.}/persist/data:/app/src/data
+      - ${HOST_PERSIST:-.}/persist/logs:/app/logs
     command: ["python", "src/manage.py", "runserver", "0.0.0.0:8000"]

--- a/docs/DJANGOPROYECTS.md
+++ b/docs/DJANGOPROYECTS.md
@@ -51,6 +51,20 @@ Aplicación básica para la creación de proyectos Django con arquitectura limpi
   }
   ```
 
+### Patrón de persistencia centralizada (persist/)
+
+- Todos los datos no versionados (secrets, media, data, logs) se centralizan en una carpeta única por host: `persist/` fuera del repositorio.
+- Bind mounts estándar desde el host al contenedor, parametrizados por `HOST_PERSIST` con default `.` para desarrollo local:
+  - `${HOST_PERSIST:-.}/persist/env/.env` → `/app/src/.env` (solo lectura)
+  - `${HOST_PERSIST:-.}/persist/media` → `/app/src/media`
+  - `${HOST_PERSIST:-.}/persist/data` → `/app/src/data`
+  - `${HOST_PERSIST:-.}/persist/logs` → `/app/logs`
+- Beneficios: resiliencia ante rebuilds/restarts/compose down, backups centralizados, menor drift entre entornos.
+- Tradeoffs: gestionar permisos UID/GID del usuario que ejecuta Docker/runner, .env en RO (640), menor aislamiento que named volumes pero mayor auditabilidad.
+- Notas SELinux/AppArmor (si aplica): puede requerir ajustar contextos o políticas para permitir bind mounts.
+  - SELinux: `chcon -Rt svirt_sandbox_file_t $HOST_PERSIST/persist` o usar `:z`/`:Z` cuando corresponda.
+  - AppArmor: verificar perfiles activos y permitir montajes en la ruta destino.
+
 ### Frontend
 - **Tailwind CSS** para estilos
 - **Estructura típica** (opcional):


### PR DESCRIPTION
Motivación: evitar desconfiguración y pérdida de estado en rebuilds/restarts/compose down/up.\n\nBeneficios:\n- Resiliencia del estado no versionado.\n- Backups simplificados y auditables.\n- Menor drift entre entornos.\n\nTradeoffs:\n- Gestión de permisos UID/GID (runner/usuario host).\n- `.env` en solo lectura (640).\n- Menor aislamiento que named volumes a cambio de mayor visibilidad.\n\nDocumentación actualizada:\n- docs/DJANGOPROYECTS.md#patrón-de-persistencia-centralizada-persist\n- docs/INSTALACION.md (sección "Persistencia centralizada").\n\nCompatibilidad: no rompe los hijos actuales (GestionFerreteria, GestionGastronomica, GestionTeatroBar). Siguiente paso sugerido: probar en uno de ellos (p.ej., GestionFerreteria) activando HOST_PERSIST y creando la estructura persist/ en el host.