### PR TITLE
chore: .gitignore robusto y agresivo con categorías comentadas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,75 @@ static/*
 src/.env
 src/media/
 logs/
+
+# ==============================
+# Runtime y artefactos generados
+# ==============================
+# Frontend y dependencias
+node_modules/
+frontend/
+
+# Archivos estáticos generados
+static/
+src/static/
+src/staticfiles/
+
+# Datos y media generados en runtime
+src/data/
+src/media/
+logs/
+
+# =========================
+# Persistencia y secretos
+# =========================
+/persist/
+/persist/**
+.env
+.envrc
+src/.env
+
+# Entornos virtuales
+.venv/
+venv/
+env/
+
+# ==============================
+# Caches y cobertura de pruebas
+# ==============================
+__pycache__/
+*.pyc
+.pytest_cache/
+.cache/
+htmlcov/
+.coverage
+.coverage.*
+
+# ==============================
+# Migraciones (plantilla agresiva)
+# ==============================
+# Ignorar migraciones por defecto en la plantilla.
+# Los hijos pueden versionarlas con un override local si lo requieren.
+src/**/migrations/*.py
+!src/**/migrations/__init__.py
+
+# ==============================
+# IDEs y tooling
+# ==============================
+.idea/
+.vscode/
+.ruff_cache/
+.ipynb_checkpoints/
+.mypy_cache/
+.pytype/
+.cursorignore
+.cursorindexingignore
+
+# ==============================
+# Logs y temporales comunes
+# ==============================
+*.log
+*.swp
+*.swo
+*.tmp
+.DS_Store
+Thumbs.db

--- a/docs/DJANGOPROYECTS.md
+++ b/docs/DJANGOPROYECTS.md
@@ -286,6 +286,24 @@ python -m pytest -q
 3. **Scaffolding**: `templates/app_templates/` se usa solo como plantilla de referencia. Nunca se ejecutan tests ni se mide cobertura allí. Al crear una nueva app, copiar la estructura a `src/<nueva_app>/` y recién entonces agregar código y tests.
 4. **Frontend**: Los scripts generan `frontend/` y compilan Tailwind a `static/css/tailwind.css`. Incluye el CSS en tus plantillas con `{% static 'css/tailwind.css' %}`.
 
+### Ignorados recomendados y por qué
+
+- **Runtime/artefactos** (frontend/, node_modules/, src/static/, src/staticfiles/, src/media/, logs/): generados en build/ejecución, reproducibles; no deben entrar al historial.
+- **Persistencia y secretos** (/persist/**, src/.env, .env*): la persistencia vive fuera del repo; ignorar secretos evita fugas accidentales.
+- **Caches/cobertura** (__pycache__/, .pytest_cache/, htmlcov/, .coverage*): ruido y tamaño innecesario.
+- **Migraciones (plantilla)**: ignoramos `src/**/migrations/*.py` salvo `__init__.py` para evitar acoplar el template a un estado de DB concreto. Los hijos pueden versionarlas con un override local si lo requieren.
+- **IDEs/tooling** (.idea/, .vscode/, .ruff_cache/, .ipynb_checkpoints/, .mypy_cache/, .pytype/): específicos del entorno del desarrollador.
+
+Overrides en hijos (si necesitan versionar algo ignorado):
+
+```gitignore
+!src/**/migrations/*.py
+# o granular, por app
+!src/app_x/migrations/*.py
+```
+
+Sugerencia: si empleas pre-commit, agrega un hook que alerte sobre intentos de commitear `.env` o `persist/`.
+
 ## Flujo de ramas y commits (resumen)
 
 Sigue `docs/GIT_AGENTES.md`:


### PR DESCRIPTION
Objetivo: prevenir commits accidentales de archivos sensibles, artefactos de runtime y migraciones innecesarias en la plantilla.\n\nCambios principales:\n- Endurecer .gitignore por categorías (runtime/artefactos, persistencia/secretos, caches/coverage, migraciones agresivas, IDE/tooling, logs/temp).\n- Documentar en docs/DJANGOPROYECTS.md la justificación por categoría y guías de override para hijos.\n\nBeneficios:\n- Repos limpios y seguros por defecto.\n- Menos ruido en historial; menor riesgo de fugas.\n\nTradeoffs:\n- Si un hijo necesita versionar algo ignorado (p.ej., migraciones), puede aplicar overrides locales, documentados en la sección nueva.