### PR TITLE
feat: entrypoint condicional y Dockerfile multi-arch/multi-stage (frontend opcional)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,93 @@
-# Base para ARM (Raspbian) – Python 3.11 sobre Debian Bookworm
-# Usa la variante slim para tamaño moderado. En Raspberry Pi (armv7/arm64)
-# Docker seleccionará automáticamente la arquitectura correcta.
-FROM python:3.11-slim-bookworm
+###############################
+# Builder de Python (multi-arch)
+###############################
+ARG PYTHON_VERSION=3.11
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETOS
+FROM --platform=$BUILDPLATFORM python:${PYTHON_VERSION}-slim-bookworm AS py-builder
 
-# Evitar creación de .pyc y mejorar logging
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 
-# Actualizar e instalar dependencias del sistema necesarias para compilar wheels en ARM
-# - build-essential, libffi-dev, libssl-dev: frecuentes para cryptography/cffi
-# - cargo, rustc: por si no hay wheel precompilado de cryptography en ARM
-# - git, curl: utilidades comunes
-# - sqlite3, libsqlite3-dev: soporte sqlite
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        build-essential \
+       gcc \
        libffi-dev \
        libssl-dev \
+       libpq-dev \
        cargo \
        rustc \
        git \
        curl \
        sqlite3 \
        libsqlite3-dev \
-       nodejs \
-       npm \
     && rm -rf /var/lib/apt/lists/*
 
-# Directorio de la app
 WORKDIR /app
 
-# Primero copiar sólo requirements para aprovechar cache de capas
+# Cache de dependencias Python como wheels
 COPY requirements/ ./requirements/
-
-# Instalar dependencias base del proyecto (usar runtime.txt para producción)
 RUN python -m pip install --upgrade pip \
-    && python -m pip install -r requirements/runtime.txt
+    && python -m pip wheel --wheel-dir=/wheels -r requirements/runtime.txt
 
-# Copiar el resto del repo
+###############################
+# Builder de Node (opcional)
+###############################
+FROM node:20-alpine AS node-builder
+WORKDIR /app
+
+# Copiar solo lo necesario para construir Tailwind (si existe)
+COPY frontend/ ./frontend/
+COPY static/ ./static/
+
+WORKDIR /app/frontend
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci || npm install \
+    && npm run build
+
+###############################
+# Runtime base sin Node/npm
+###############################
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       sqlite3 \
+       libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Instalar dependencias desde wheels (no requiere toolchain aquí)
+COPY --from=py-builder /wheels /wheels
+COPY requirements/ ./requirements/
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-index --find-links=/wheels -r requirements/runtime.txt
+
+# Copiar la aplicación
 COPY . .
-
-# Crear carpeta de datos si aplica (sqlite)
 RUN mkdir -p /app/src/data
 
-# Copiar entrypoint y dar permisos
+# Entrypoint
 COPY scripts/docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Exponer puerto por defecto de Django
 EXPOSE 8000
-
-# Comando por defecto: servidor de desarrollo (puedes sobreescribir con CMD en docker run)
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "src/manage.py", "runserver", "0.0.0.0:8000"]
+
+########################################
+# Runtime con frontend (copia estáticos)
+########################################
+FROM runtime AS runtime-frontend
+
+# Nota: este stage solo copia artefactos estáticos construidos por Node.
+# No incluye Node/npm en la imagen final.
+COPY --from=node-builder /app/static/css /app/static/css


### PR DESCRIPTION
Objetivo: imágenes runtime limpias sin Node en producción, soporte ARM nativo (amd64/arm64/armv7), frontend completamente opcional vía targets y flags.

Beneficios:
- Reducción de tamaño y superficie de ataque (stage final sin Node/npm/toolchain).
- Flexibilidad: --target runtime para prod sin frontend, runtime-frontend para staging.
- Condicionales en entrypoint (NO_FRONTEND, ENABLE_COLLECTSTATIC, RUN_MAKEMIGRATIONS).
- Logging claro y creación segura de src/.env.

Tradeoffs:
- Mayor complejidad en Dockerfile (mitigada con docs claras y recomendaciones de --target).
- Coordinación de targets/args (documentado en docs/DJANGOPROYECTS.md).

Cambios:
- feat(docker): multi-stage/multi-arch con targets runtime y runtime-frontend.
- feat(entrypoint): flags condicionales y lógica segura.
- docs: sección 'Perfiles de build y frontend condicional' + recetas multi-arch.

Compatibilidad: no rompe hijos actuales (comportamiento por defecto conservador).

Enlaces:
- docs/DJANGOPROYECTS.md#perfiles-de-build-y-frontend-condicional
- docs/RECETAS_DEPLOY.md (nuevas recetas de build)