### PR TITLE
feat: CLI genérico project_manage.py + Makefile delegando

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Makefile delgado: delega en project_manage.py
+PY ?= python
+CLI ?= project_manage.py
+
+# Variables forward comunes
+PROFILE ?=
+PROFILES ?=
+SERVICES ?=
+FOLLOW ?=
+
+export PROFILE PROFILES SERVICES FOLLOW
+
+.PHONY: up down restart rebuild logs migrate status info compose clean
+
+up:
+	$(PY) $(CLI) up
+
+down:
+	$(PY) $(CLI) down
+
+restart:
+	$(PY) $(CLI) restart
+
+rebuild:
+	$(PY) $(CLI) rebuild
+
+logs:
+	$(PY) $(CLI) logs
+
+migrate:
+	$(PY) $(CLI) migrate
+
+status:
+	$(PY) $(CLI) status
+
+info:
+	$(PY) $(CLI) info
+
+# Passthrough a docker compose: usar como `make compose ARGS="up -d --profile db"`
+compose:
+	$(PY) $(CLI) compose -- $(ARGS)
+
+# Utilidad opcional
+clean:
+	$(PY) -c "import shutil,sys; [shutil.rmtree(p, ignore_errors=True) for p in ['.pytest_cache','__pycache__','src/**/__pycache__','htmlcov']]" || true
+	$(PY) $(CLI) down --volumes || true
+
+# Permite que los hijos extiendan con objetivos propios
+-include Makefile.local

--- a/docs/DJANGOPROYECTS.md
+++ b/docs/DJANGOPROYECTS.md
@@ -358,3 +358,37 @@ Convencional Commits (resumen):
   - `chore(docker): añadir .dockerignore`
   - `feat(deps): crear requirements/runtime.txt para producción`
   - `docs(docker): instrucciones de build y uso (compose con restart always)`
+
+## CLI de gestión del proyecto
+
+El proyecto incluye un CLI genérico `project_manage.py` y un `Makefile` que delega en él para estandarizar operaciones comunes.
+
+Comandos principales:
+- `up`: Levanta servicios (`docker compose up -d`). Flags: `--profile`, `--build`.
+- `down`: Detiene y elimina (`docker compose down`). Flags: `--volumes`, `--remove-orphans`.
+- `restart`: Reinicia servicios. Flags: `--services`.
+- `rebuild`: Reconstruye imágenes. Flags: `--no-cache`, `--pull`, `--profile`.
+- `logs`: Muestra logs. Flags: `-f/--follow`, `--since`, `--tail`, `--services`.
+- `migrate`: Ejecuta migraciones controladas. Flag: `--makemigrations` (opcional; por defecto no ejecuta).
+- `status`: Estado de servicios (`docker compose ps`).
+- `trigger` (opcional): Dispara una tarea Celery si worker/broker están activos.
+- `compose`: Passthrough a `docker compose` para casos avanzados.
+- `info`: Muestra contexto (perfiles, servicios, flags de entrypoint, etc.).
+
+Uso con Makefile (atajos):
+- `make up`, `make down`, `make logs`, `make migrate`, `make status`, `make info`.
+
+Variables útiles (se propagan):
+- `PROFILE`/`PROFILES`: perfiles de compose (p. ej. `db,broker,worker`).
+- `SERVICES`: lista de servicios (p. ej. `app,worker`).
+- `FOLLOW=1`: seguir logs (`-f`).
+
+Extensión en hijos:
+- Crear `Makefile.local` con targets propios, por ejemplo:
+  ```make
+  custom-task:
+  	python project_manage.py compose -- exec app python src/manage.py custom_command
+  ```
+
+Racional:
+- Consistencia entre padre e hijos, menos comandos largos de compose, tolerancia a perfiles opcionales.

--- a/docs/RECETAS_DEPLOY.md
+++ b/docs/RECETAS_DEPLOY.md
@@ -93,3 +93,21 @@ docker buildx bake
 1. `docker compose down`
 2. Restaurar snapshot de `persist/` (ver guía en docs/INSTALACION.md)
 3. `docker compose up -d`
+
+---
+
+## Usando el CLI (atajos)
+
+Ejemplos equivalentes con `project_manage.py`/`Makefile`:
+
+```bash
+# Migraciones controladas
+python project_manage.py migrate
+
+# Levantar servicios con perfiles
+PROFILE=db,broker,worker make up
+
+# Estado y logs
+python project_manage.py status
+FOLLOW=1 SERVICES=app,worker make logs
+```

--- a/project_manage.py
+++ b/project_manage.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from typing import List
+
+
+def run(cmd: List[str], tolerate=False) -> int:
+    print(f"\n$ {' '.join(shlex.quote(c) for c in cmd)}")
+    try:
+        proc = subprocess.run(cmd, check=not tolerate)
+        return proc.returncode
+    except subprocess.CalledProcessError as e:
+        if tolerate:
+            print(f"[skip] comando falló pero se tolera: {e}")
+            return e.returncode
+        raise
+
+
+def compose_cmd() -> List[str]:
+    return ["docker", "compose"]
+
+
+def add_common_args(p: argparse.ArgumentParser):
+    p.add_argument("--profile", dest="profiles", help="Perfiles separados por coma (db,broker,worker,frontend)")
+    p.add_argument("--services", help="Servicios separados por coma (app,db,worker)")
+
+
+def parse_profiles(args) -> List[str]:
+    value = args.profiles or os.environ.get("PROFILE") or os.environ.get("PROFILES")
+    if not value:
+        return []
+    return [p.strip() for p in value.split(",") if p.strip()]
+
+
+def parse_services(args) -> List[str]:
+    value = args.services or os.environ.get("SERVICES")
+    if not value:
+        return []
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def cmd_up(args):
+    cmd = compose_cmd() + ["up", "-d"]
+    if args.build or os.environ.get("BUILD") == "1":
+        cmd.append("--build")
+    for p in parse_profiles(args):
+        cmd += ["--profile", p]
+    return run(cmd, tolerate=True)
+
+
+def cmd_down(args):
+    cmd = compose_cmd() + ["down"]
+    if args.volumes:
+        cmd.append("--volumes")
+    if args.remove_orphans:
+        cmd.append("--remove-orphans")
+    return run(cmd, tolerate=True)
+
+
+def cmd_restart(args):
+    cmd = compose_cmd() + ["restart"]
+    services = parse_services(args)
+    if services:
+        cmd += services
+    return run(cmd, tolerate=True)
+
+
+def cmd_rebuild(args):
+    cmd = compose_cmd() + ["build"]
+    if args.no_cache:
+        cmd.append("--no-cache")
+    if args.pull:
+        cmd.append("--pull")
+    for p in parse_profiles(args):
+        cmd += ["--profile", p]
+    return run(cmd, tolerate=True)
+
+
+def cmd_logs(args):
+    cmd = compose_cmd() + ["logs"]
+    if args.follow or os.environ.get("FOLLOW") == "1":
+        cmd.append("-f")
+    if args.since:
+        cmd += ["--since", args.since]
+    if args.tail:
+        cmd += ["--tail", str(args.tail)]
+    services = parse_services(args)
+    if services:
+        cmd += services
+    return run(cmd, tolerate=True)
+
+
+def cmd_migrate(args):
+    # makemigrations (opcional, por defecto false)
+    if args.makemigrations:
+        run(compose_cmd() + ["run", "--rm", "app", "python", "src/manage.py", "makemigrations", "--noinput"], tolerate=True)
+    # migrate (siempre)
+    return run(compose_cmd() + ["run", "--rm", "app", "python", "src/manage.py", "migrate", "--noinput"], tolerate=False)
+
+
+def cmd_status(_args):
+    return run(compose_cmd() + ["ps"], tolerate=True)
+
+
+def cmd_trigger(args):
+    # Verificar si worker/broker existen; si no, avisar y salir sin error
+    rc_worker = run(compose_cmd() + ["ps", "worker"], tolerate=True)
+    rc_broker = run(compose_cmd() + ["ps", "redis"], tolerate=True)
+    if rc_worker != 0 or rc_broker != 0:
+        print("[skip] worker/broker no activos o no definidos; trigger omitido.")
+        return 0
+    task = args.task
+    task_args = args.args or "{}"
+    return run(compose_cmd() + [
+        "exec", "-T", "worker", "python", "src/manage.py", "shell", "-c",
+        f"from celery import current_app as app; import json; app.send_task('{task}', kwargs=json.loads('''{task_args}'''))"
+    ], tolerate=True)
+
+
+def cmd_compose(args):
+    # Passthrough: todo lo que sigue a -- se envía tal cual a docker compose
+    if not args.passthrough:
+        print("Nada para pasar a docker compose. Usa: project_manage.py compose -- <args>")
+        return 1
+    return run(compose_cmd() + args.passthrough, tolerate=True)
+
+
+def cmd_info(_args):
+    print("Proyecto:", os.path.basename(os.getcwd()))
+    print("Rama (si aplica):", os.environ.get("GIT_BRANCH", "(no detectada)"))
+    print("Perfiles (PROFILE/PROFILES):", os.environ.get("PROFILE") or os.environ.get("PROFILES") or "(no definidos)")
+    print("Servicios (SERVICES):", os.environ.get("SERVICES") or "(no definidos)")
+    print("Flags entrypoint relevantes:")
+    print("  NO_FRONTEND=", os.environ.get("NO_FRONTEND"))
+    print("  ENABLE_COLLECTSTATIC=", os.environ.get("ENABLE_COLLECTSTATIC"))
+    print("  RUN_MAKEMIGRATIONS=", os.environ.get("RUN_MAKEMIGRATIONS"))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="project_manage.py", description="CLI de gestión para DjangoProyects")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("up", help="Levanta servicios (docker compose up -d)")
+    add_common_args(sp)
+    sp.add_argument("--build", action="store_true", help="Forzar build al levantar")
+    sp.set_defaults(func=cmd_up)
+
+    sp = sub.add_parser("down", help="Detiene y elimina servicios (docker compose down)")
+    sp.add_argument("--volumes", action="store_true", help="Elimina volúmenes")
+    sp.add_argument("--remove-orphans", action="store_true", help="Elimina huérfanos")
+    sp.set_defaults(func=cmd_down)
+
+    sp = sub.add_parser("restart", help="Reinicia servicios (docker compose restart)")
+    add_common_args(sp)
+    sp.set_defaults(func=cmd_restart)
+
+    sp = sub.add_parser("rebuild", help="Reconstruye imágenes (docker compose build)")
+    add_common_args(sp)
+    sp.add_argument("--no-cache", action="store_true")
+    sp.add_argument("--pull", action="store_true")
+    sp.set_defaults(func=cmd_rebuild)
+
+    sp = sub.add_parser("logs", help="Logs de servicios (docker compose logs)")
+    add_common_args(sp)
+    sp.add_argument("-f", "--follow", action="store_true")
+    sp.add_argument("--since", help="Tiempo relativo/absoluto, ej: 2m, 2024-01-01T00:00")
+    sp.add_argument("--tail", type=int, help="Cantidad de líneas por servicio")
+    sp.set_defaults(func=cmd_logs)
+
+    sp = sub.add_parser("migrate", help="Ejecuta migraciones controladas")
+    sp.add_argument("--makemigrations", action="store_true", help="Ejecutar makemigrations antes de migrate")
+    sp.set_defaults(func=cmd_migrate)
+
+    sp = sub.add_parser("status", help="Estado de servicios (docker compose ps)")
+    sp.set_defaults(func=cmd_status)
+
+    sp = sub.add_parser("trigger", help="Dispara una tarea Celery (si worker/broker activos)")
+    sp.add_argument("--task", required=True, help="Ruta de la tarea, ej: core_app.tasks.rebuild_cache")
+    sp.add_argument("--args", help="JSON de kwargs para la tarea")
+    sp.set_defaults(func=cmd_trigger)
+
+    sp = sub.add_parser("compose", help="Passthrough a docker compose: project_manage.py compose -- <args>")
+    sp.add_argument("passthrough", nargs=argparse.REMAINDER)
+    sp.set_defaults(func=cmd_compose)
+
+    sp = sub.add_parser("info", help="Información de contexto del proyecto")
+    sp.set_defaults(func=cmd_info)
+
+    return p
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Objetivo: centralizar comandos operativos comunes (up/down/logs/migrate/status/etc.) en un CLI Python tolerante a perfiles opcionales, con Makefile delgado que delega.

Beneficios:
- Consistencia entre padre e hijos.
- Menos comandos largos de compose y errores tipográficos.
- Tolerancia: ignora servicios no activos (db/broker/worker) con mensajes claros.
- Extensible: passthrough 'compose' y Makefile.local para overrides en hijos.

Cambios:
- feat(cli): project_manage.py con comandos base y tolerancia.
- chore(makefile): delegación a CLI + inclusión Makefile.local.
- docs: sección CLI en DJANGOPROYECTS.md + ejemplos de uso/extensión.

Compatibilidad: no rompe flujos existentes; CLI nuevo es opt-in.

Enlaces:
- docs/DJANGOPROYECTS.md#cli-de-gestión-del-proyecto