### PR TITLE
feat: perfiles en docker-compose para servicios opcionales (db, broker, worker, frontend)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,7 @@ services:
       - ${HOST_PERSIST:-.}/persist/media:/app/src/media
       - ${HOST_PERSIST:-.}/persist/data:/app/src/data
       - ${HOST_PERSIST:-.}/persist/logs:/app/logs
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
+    # Nota: sin depends_on para no forzar perfiles opcionales (db/broker) en base
     healthcheck:
       test: ["CMD-SHELL", "python src/manage.py check --deploy || exit 1"]
       interval: 10s
@@ -44,7 +40,7 @@ services:
       retries: 10
       start_period: 10s
     volumes:
-      - ${HOST_PERSIST:-.}/persist/data:/var/lib/postgresql/data
+      - ${HOST_PERSIST:-.}/persist/data/postgres:/var/lib/postgresql/data
 
   redis:
     profiles: ["broker"]
@@ -57,4 +53,33 @@ services:
       retries: 10
       start_period: 5s
     volumes:
-      - ${HOST_PERSIST:-.}/persist/data:/data
+      - ${HOST_PERSIST:-.}/persist/data/redis:/data
+
+  worker:
+    profiles: ["worker"]
+    build: .
+    image: django-proyects:worker
+    restart: always
+    environment:
+      - NO_FRONTEND=true
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python src/manage.py check || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
+    command: ["bash", "-lc", "celery -A src.core_config worker -l info"]
+
+  frontend:
+    profiles: ["frontend"]
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    volumes:
+      - ./static:/usr/share/nginx/html:ro

--- a/docs/DJANGOPROYECTS.md
+++ b/docs/DJANGOPROYECTS.md
@@ -392,3 +392,36 @@ Extensión en hijos:
 
 Racional:
 - Consistencia entre padre e hijos, menos comandos largos de compose, tolerancia a perfiles opcionales.
+
+## Perfiles de ejecución con docker compose
+
+Perfiles disponibles:
+- base (implícito): solo `app` con SQLite. No requiere `--profile`.
+- db: agrega `db` (Postgres) con volumen persistente `persist/data/postgres`.
+- broker: agrega `redis` con volumen `persist/data/redis` (opcional).
+- worker: agrega `worker` (Celery) que depende de `db` y `redis` cuando están activos.
+- frontend: agrega un servicio ligero para servir estáticos (p. ej., Nginx). Úsalo solo si tu hijo lo necesita.
+
+Cómo activarlos:
+```bash
+# App + DB
+docker compose --profile db up -d
+
+# App + DB + Broker
+docker compose --profile db --profile broker up -d
+
+# App + DB + Broker + Worker (sin frontend)
+docker compose --profile db --profile broker --profile worker up -d
+
+# Con CLI/Makefile
+PROFILE=db,broker,worker make up
+python project_manage.py up --profile db,broker,worker
+```
+
+Beneficios:
+- Padre minimalista por defecto: hijos sin DB/Celery no cargan servicios innecesarios.
+- Control granular por entorno: activa solo lo que necesitas.
+
+Tradeoffs:
+- Debes indicar `--profile` cuando requieras servicios opcionales.
+- Mitigación: usa `PROFILE=... make up` o `project_manage.py up --profile ...`.


### PR DESCRIPTION
Objetivo: permitir activar servicios opcionales de forma granular sin forzarlos en todos los entornos/hijos, manteniendo el padre minimalista por defecto (solo app + SQLite en perfil base).

Beneficios:
- Minimalismo: hijos sin DB/Celery no cargan overhead.
- Control: activar exactamente lo necesario con --profile.
- Consistencia: perfiles coherentes con CLI/Makefile y persist/.

Cambios:
- feat(compose): profiles: ["db"], ["broker"], ["worker"], ["frontend"] en servicios opcionales.
- docs: sección 'Perfiles de ejecución con docker compose' + ejemplos combinados con CLI.

Compatibilidad: no rompe flujos existentes; perfil base implícito funciona sin --profile.

Enlaces:
- docs/DJANGOPROYECTS.md#perfiles-de-ejecución-con-docker-compose