### PR TITLE
feat: settings modulares con toggles genéricos + README/docs modular para hijos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
-# Nombre del Proyecto
+# DjangoProyects (plantilla)
 
-Breve descripción del proyecto. Este repositorio se generó a partir de la plantilla DjangoProyects.
+Plantilla base para proyectos Django con arquitectura limpia, CLI unificado y dockerización lista para producción.
 
-## Documentación de la plantilla
+- Documentación completa: ver [docs/DJANGOPROYECTS.md](docs/DJANGOPROYECTS.md)
+- Instalación y comandos rápidos: [docs/INSTALACION.md](docs/INSTALACION.md)
 
-- Guía completa de DjangoProyects: ver [docs/DJANGOPROYECTS.md](docs/DJANGOPROYECTS.md).
-- Instalación y comandos rápidos: ver [docs/INSTALACION.md](docs/INSTALACION.md).
-
-### Persistencia en producción
-
-Este template adopta una carpeta `persist/` por host para centralizar secretos, media, data y logs mediante bind mounts controlados por `HOST_PERSIST` (default `.` en desarrollo).
-Consulta detalles y pasos en:
-- [docs/DJANGOPROYECTS.md](docs/DJANGOPROYECTS.md#patrón-de-persistencia-centralizada-persist)
-- [docs/INSTALACION.md](docs/INSTALACION.md)
+Notas importantes:
+- Persistencia: usamos `persist/` por host (ver sección correspondiente en docs).
+- Este README del padre es genérico. Los hijos deben mantener su propio README específico y NO se sincroniza desde el padre (evita ruido en diffs). 

--- a/docs/DJANGOPROYECTS.md
+++ b/docs/DJANGOPROYECTS.md
@@ -425,3 +425,38 @@ Beneficios:
 Tradeoffs:
 - Debes indicar `--profile` cuando requieras servicios opcionales.
 - Mitigación: usa `PROFILE=... make up` o `project_manage.py up --profile ...`.
+
+## Toggles de configuración (settings modulares)
+
+Los ajustes del proyecto se parametrizan vía `.env` (python-decouple). Principales toggles:
+
+- `USE_POSTGRES` (bool, default False):
+  - False → SQLite por defecto.
+  - True → Configura Postgres con `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT`.
+- `CELERY_ENABLED` (bool, default False): habilita configuración de Celery. No requiere que el perfil `worker` esté activo para correr la app.
+- `WHITENOISE_ENABLED` (bool, default `not DEBUG`): sirve estáticos en producción con WhiteNoise.
+- `ALLAUTH_ENABLED` (bool, default True) y `ALLAUTH_PROVIDERS` (CSV: `github,google`): añade proveedores de autenticación social condicionalmente.
+- `ALLOWED_HOSTS` (CSV), `CSRF_TRUSTED_ORIGINS` (CSV): seguridad por entorno.
+- `DEBUG_INFO` (bool, default False): incrementa logging en staging/desarrollo.
+
+Ejemplos:
+```env
+DEBUG=False
+USE_POSTGRES=True
+POSTGRES_HOST=db
+CELERY_ENABLED=True
+ALLAUTH_PROVIDERS=github
+```
+
+Relación con perfiles de compose:
+- Activa sólo los perfiles necesarios en Docker (`db`, `broker`, `worker`). Los toggles no fuerzan servicios; sólo parametrizan la app.
+
+## Estrategia de documentación modular (padre vs hijos)
+
+- README del padre (este repo): breve y genérico; apunta a esta documentación.
+- README de cada hijo: específico y personalizado (nombre, propósito, enlaces, capturas). No se sincroniza desde el padre para evitar ruido en diffs.
+- Esta documentación (`docs/DJANGOPROYECTS.md`) es la fuente de verdad genérica y se actualiza desde el padre.
+
+Al migrar un hijo:
+- Actualiza el hijo con los cambios del padre en código y en `docs/DJANGOPROYECTS.md`.
+- No sobrescribas el `README.md` del hijo; edítalo manualmente para mantener lo específico y enlaza a `docs/DJANGOPROYECTS.md`.

--- a/docs/README_HIJOS_TEMPLATE.md
+++ b/docs/README_HIJOS_TEMPLATE.md
@@ -1,0 +1,14 @@
+# {{NOMBRE_PROYECTO}}
+
+{{DESCRIPCION_CORTA}}
+
+## Enlaces útiles
+- Demo: {{ENLACES_DEMO}}
+- Documentación genérica de la plantilla (padre): docs/DJANGOPROYECTS.md
+- Contacto: {{CONTACTO}}
+
+## Notas del proyecto
+- Contexto/objetivos: {{OBJETIVOS}}
+- Consideraciones operativas: {{OPERACION}}
+
+> Para operaciones genéricas (CLI, perfiles compose, toggles de settings, Docker), consultar la documentación de la plantilla en docs/DJANGOPROYECTS.md.

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,16 +1,43 @@
-# Variables de entorno para DjangoProyects
-# Copia este archivo a src/.env y ajusta los valores
+############################################################
+# DjangoProyects (.env.example)
+# Copiar a: persist/env/.env  (o a src/.env en desarrollo)
+# HOST_PERSIST=/ruta/en/host  # opcional, default '.'
+############################################################
 
+# Core
 SECRET_KEY=changeme_super_secret_key
 DEBUG=True
-ALLOWED_HOSTS=127.0.0.1,localhost
+ALLOWED_HOSTS=127.0.0.1,localhost,0.0.0.0
+DEBUG_INFO=False
+
+# Base de datos
+USE_POSTGRES=False
+POSTGRES_DB=app
+POSTGRES_USER=app
+POSTGRES_PASSWORD=app
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+
+# Celery (opcional)
+CELERY_ENABLED=False
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/1
+
+# Estáticos
+WHITENOISE_ENABLED=
+
+# Allauth (opcional)
+ALLAUTH_ENABLED=True
+ALLAUTH_PROVIDERS=github
+GITHUB_CLIENT_ID=
+GITHUB_SECRET=
+
+# Seguridad (opcional)
+CSRF_TRUSTED_ORIGINS=
+# CORS_ALLOWED_ORIGINS=
 
 # Personalización de la app
 NOMBRE_APLICACION=DjangoProyects
 WHATSAPP_CONTACT=+00 000 000 000
 PASSWORD_RESET_TICKET_TTL_HOURS=48
 TEMP_PASSWORD_LENGTH=16
-
-# OAuth (si usas social login)
-GITHUB_CLIENT_ID=
-GITHUB_SECRET=


### PR DESCRIPTION
Objetivo: parametrizar servicios opcionales vía .env (Postgres, Celery, WhiteNoise, allauth) y aislar README/docs específicos de hijos para evitar ruido en diffs al sincronizar con padre.

Beneficios:
- Activación granular sin tocar código (solo .env).
- README hijo enfocado en lo específico; docs genéricas centralizadas.
- Menos drift y conflictos en merges/sync.

Cambios:
- feat(settings): toggles USE_POSTGRES, CELERY_ENABLED, etc. con defaults seguros.
- chore(env): .env.example limpio y genérico.
- docs: README padre breve + sección toggles y estrategia modular.
- docs: plantilla README_HIJOS_TEMPLATE.md (opcional).

Compatibilidad: no rompe hijos actuales; toggles usan defaults conservadores; README hijo queda aislado.

Enlaces:
- docs/DJANGOPROYECTS.md#toggles-de-configuración-settings-modulares
- docs/DJANGOPROYECTS.md#estrategia-de-documentación-modular-padre-vs-hijos